### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Welcome to CatsCorner!
 
-This is a space where I will document my learning journey in functional programming using the Cats library. As I continue to learn and grow, I will use this project share my insights with others in the community.
+This is a space where I will document my learning journey in functional programming using the Cats library. As I continue to learn and grow, I will use this project to share my insights with others in the community.
 
 With CatsCorner, I hope to inspire and encourage others to explore the world of functional programming, and to show how Cats can help them unlock the full potential of functional programming in Scala.
 
-A number of excellent books and resources that have helped me to develop my understanding of functional programming and Cats. These resources include:
+There are a number of excellent books and resources that have helped me to develop my understanding of functional programming and Cats. These resources include:
 
 - Functional Programming in Scala by Paul Chiusano and Rúnar Bjarnason
 - Scala with Cats by Noel Welsh and Dave Gurnell
-- Cats documentation and examples on Github
+- Cats documentation and examples on GitHub
 
 I highly recommend these resources to anyone who is interested in learning more about functional programming and Cats, as they provide excellent insights and practical advice for developers of all levels.
 


### PR DESCRIPTION
## Summary
- fix grammatical error: add missing `to`
- improve sentence introducing resources
- capitalize GitHub

## Testing
- `true`
